### PR TITLE
Fixed default method for interp1

### DIFF
--- a/R/interp1.R
+++ b/R/interp1.R
@@ -1,5 +1,5 @@
 interp1 <- function (x, y, xi = x,
-             method = c("constant", "linear", "nearest", "spline", "cubic"))
+             method = c("linear", "constant", "nearest", "spline", "cubic"))
 {
     if (!is.vector(x, mode="numeric") || !is.vector(y, mode="numeric"))
         stop("Arguments 'x' and 'y' must be numeric vectors.")

--- a/man/interp1.Rd
+++ b/man/interp1.Rd
@@ -8,7 +8,7 @@
 }
 \usage{
 interp1(x, y, xi = x,
-        method = c("constant", "linear", "nearest", "spline", "cubic"))
+        method = c("linear", "constant", "nearest", "spline", "cubic"))
 }
 \arguments{
   \item{x}{Numeric vector; points on the x-axis; at least two points require;
@@ -17,7 +17,7 @@ interp1(x, y, xi = x,
            \code{x} and \code{y} must be of the same length.}
   \item{xi}{Numeric vector; points at which to compute the interpolation;
             all points must lie between \code{min(x)} and \code{max(x)}.}
-  \item{method}{One of ``constant", ``linear", ``nearest", ``spline", or ``cubic".}
+  \item{method}{One of ``linear", ``constant", ``nearest", ``spline", or ``cubic".}
 }
 \details{
   Interpolation to find \code{yi}, the values of the underlying function
@@ -25,8 +25,8 @@ interp1(x, y, xi = x,
 
   Methods can be:
   \tabular{ll}{
-  \code{constant} \tab constant between points \cr
   \code{linear} \tab linear interpolation (default) \cr
+  \code{constant} \tab constant between points \cr
   \code{nearest} \tab nearest neighbor interpolation \cr
   \code{spline} \tab cubic spline interpolation \cr
   \code{cubic} \tab cubic Hermite interpolation \cr

--- a/tests/interp1.R
+++ b/tests/interp1.R
@@ -9,6 +9,8 @@ x <- c(0.0, 0.5, 1.0, 1.5)
 y <- x^2
 xi <- c(0.25, 0.75, 1.25)
 
+# without explicit method should be the same as linear
+identical(interp1(x, y, xi), interp1(x, y, xi, method="linear"))
 identical(interp1(x, y, xi, method="constant"), c(0.0, 0.25, 1.0))
 identical(interp1(x, y, xi, method="linear"),   c(0.125, 0.625, 1.625))
 identical(interp1(x, y, xi, method="nearest"),  c(0.25, 1.00, 2.25))


### PR DESCRIPTION
Hi, I fixed an issue with interp1: when you call it without specifying a method, it picks "constant" instead of "linear". I also updated the autotester to catch this and updated the doc.
