### PR TITLE
Update pinv.R

### DIFF
--- a/R/pinv.R
+++ b/R/pinv.R
@@ -4,7 +4,7 @@
 
 
 pinv <- function (A, tol = .Machine$double.eps^(2/3)) {
-    stopifnot(is.numeric(A), length(dim(A)) == 2, is.matrix(A))
+    stopifnot(is.numeric(A) | is.complex(A), length(dim(A)) == 2, is.matrix(A))
 
     s <- svd(A)
     # D <- diag(s$d); Dinv <- diag(1/s$d)


### PR DESCRIPTION
Possible bug: is.numeric(A) returns FALSE for complex matrices however Moore-Penrose Generalized Inverse should hold for complex as well. 

This is causing an error when I use mldivide(A,B) on a complex matrix A.